### PR TITLE
:sparkles: manage vpas for daemonsets

### DIFF
--- a/pkg/handler/daemonset.go
+++ b/pkg/handler/daemonset.go
@@ -1,0 +1,52 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"strings"
+
+	"github.com/fairwindsops/goldilocks/pkg/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+	"github.com/fairwindsops/goldilocks/pkg/vpa"
+)
+
+// OnDaemonSetChanged is a handler that should be called when a daemon set changes.
+func OnDaemonSetChanged(daemonSet *appsv1.DaemonSet, event utils.Event) {
+	kubeClient := kube.GetInstance()
+	namespace, err := kube.GetNamespace(kubeClient, event.Namespace)
+	if err != nil {
+		klog.Error("Handler got error retrieving namespace object. Breaking.")
+		return
+	}
+	switch strings.ToLower(event.EventType) {
+	case "delete":
+		klog.V(3).Infof("DaemonSet %s deleted. Deleting the VPA for it if it had one.", daemonSet.ObjectMeta.Name)
+		err := vpa.GetInstance().ReconcileNamespace(namespace)
+		if err != nil {
+			klog.Errorf("Error reconciling: %v", err)
+		}
+	case "create", "update":
+		klog.V(3).Infof("DaemonSet %s updated. Reconcile", daemonSet.ObjectMeta.Name)
+		err := vpa.GetInstance().ReconcileNamespace(namespace)
+		if err != nil {
+			klog.Errorf("Error reconciling: %v", err)
+		}
+	default:
+		klog.V(3).Infof("Update type %s is not valid, skipping.", event.EventType)
+	}
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -42,6 +42,8 @@ func OnUpdate(obj interface{}, event utils.Event) {
 		OnNamespaceChanged(obj.(*corev1.Namespace), event)
 	case *appsv1.StatefulSet:
 		OnStatefulSetChanged(obj.(*appsv1.StatefulSet), event)
+	case *appsv1.DaemonSet:
+		OnDaemonSetChanged(obj.(*appsv1.DaemonSet), event)
 	default:
 		klog.Errorf("Object has unknown type of %T", t)
 	}
@@ -56,6 +58,8 @@ func onDelete(event utils.Event) {
 		OnDeploymentChanged(&appsv1.Deployment{}, event)
 	case "statefulset":
 		OnStatefulSetChanged(&appsv1.StatefulSet{}, event)
+	case "daemonset":
+		OnDaemonSetChanged(&appsv1.DaemonSet{}, event)
 	default:
 		klog.Errorf("object has unknown resource type %s", event.ResourceType)
 	}

--- a/pkg/vpa/test_constants.go
+++ b/pkg/vpa/test_constants.go
@@ -88,12 +88,24 @@ var testDeployment = &appsv1.Deployment{
 	},
 }
 
+// A stateful set object that can be used for testing
 var testStatefulSet = &appsv1.StatefulSet{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "test-deploy",
 	},
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "StatefulSet",
+		APIVersion: "apps/v1",
+	},
+}
+
+// A daemon set object that can be used for testing
+var testDaemonSet = &appsv1.DaemonSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-deploy",
+	},
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "DaemonSet",
 		APIVersion: "apps/v1",
 	},
 }

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -504,15 +504,19 @@ func Test_ReconcileNamespaceWithLabels(t *testing.T) {
 	_, err = KubeClient.Client.AppsV1().StatefulSets(nsName).Create(context.TODO(), testStatefulSet, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	// This should create a 2 VPAs
+	_, err = KubeClient.Client.AppsV1().DaemonSets(nsName).Create(context.TODO(), testDaemonSet, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// This should create a 3 VPAs
 	err = GetInstance().ReconcileNamespace(nsLabeledTrue)
 	assert.NoError(t, err)
 
 	vpaList, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).List(context.TODO(), metav1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(vpaList.Items))
+	assert.Equal(t, 3, len(vpaList.Items))
 	assert.Equal(t, "test-deploy-deployment", vpaList.Items[0].ObjectMeta.Name)
 	assert.Equal(t, "test-deploy-statefulset", vpaList.Items[1].ObjectMeta.Name)
+	assert.Equal(t, "test-deploy-daemonset", vpaList.Items[2].ObjectMeta.Name)
 }
 
 func Test_ReconcileNamespaceDeleteDeployment(t *testing.T) {


### PR DESCRIPTION
Allow goldilocks to create VPAs for daemon sets 